### PR TITLE
Added ability to configure Redis with multiple sentinel URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ for more information.
 ### Redis
 
 To configure redis client, either use `host` (defaults to `localhost`)
-or `service_id` to provide custom `Predis\Redis` service.
+or `parameters` and `options` (allows to configure connection to redis sentinels)
+or `service_id` to provide custom `Predis\Redis` service
 
 You can configure `prefix` for additional prefix for all created keys.
 
@@ -261,6 +262,12 @@ instead of unhandled exception causing `500` responses.
 maba_gentle_force:
     redis:
         host:                 ~
+        parameters:           []
+        options: 
+            replication:      ~
+            service:          ~
+            parameters:
+                password:     ~
         service_id:           ~
         prefix:               ~
         failure_strategy:     fail

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,14 @@ class Configuration implements ConfigurationInterface
     private function configureRedis(ArrayNodeDefinition $node)
     {
         $builder = $node->children();
-        $builder->scalarNode('host');
+        $builder->scalarNode('host')->defaultValue('localhost')->end();
+        $builder->arrayNode('parameters')->prototype('scalar')->end();
+        $builder->arrayNode('options')
+            ->children()->scalarNode('replication')->end()->end()
+            ->children()->scalarNode('service')->end()->end()
+            ->children()->arrayNode('parameters')
+                ->children()->scalarNode('password')->end()->end()
+            ->end();
         $builder->scalarNode('service_id');
         $builder->scalarNode('prefix')->defaultNull();
         $builder->scalarNode('failure_strategy')
@@ -40,8 +47,12 @@ class Configuration implements ConfigurationInterface
         ;
 
         $node->validate()->ifTrue(function ($nodeConfig) {
-            return isset($nodeConfig['host']) && isset($nodeConfig['service_id']);
-        })->thenInvalid('Only one of host and service_id must be provided');
+            return isset($nodeConfig['host'])
+                && isset($nodeConfig['service_id'])
+                && isset($nodeConfig['parameters'])
+                && isset($nodeConfig['options'])
+            ;
+        })->thenInvalid('Only one of host, service_id or parameters and options must be provided');
     }
 
     private function configureLimits(ArrayNodeDefinition $node)

--- a/src/DependencyInjection/MabaGentleForceExtension.php
+++ b/src/DependencyInjection/MabaGentleForceExtension.php
@@ -86,15 +86,21 @@ class MabaGentleForceExtension extends Extension
 
         if (isset($redisConfig['service_id'])) {
             $container->setAlias('maba_gentle_force.redis_client', $redisConfig['service_id']);
-
             return;
         }
 
-        $parameters = null;
-        if (isset($redisConfig['host'])) {
-            $parameters = ['host' => $redisConfig['host']];
+        $parameters = ['host' => $redisConfig['host']];
+        $options = null;
+
+        if (isset($redisConfig['parameters'])) {
+            $parameters = $redisConfig['parameters'];
         }
-        $redisClientDefinition = new Definition(Client::class, [$parameters]);
+
+        if (isset($redisConfig['options'])) {
+            $options = $redisConfig['options'];
+        }
+
+        $redisClientDefinition = new Definition(Client::class, [$parameters, $options]);
         $container->setDefinition('maba_gentle_force.redis_client', $redisClientDefinition);
     }
 

--- a/src/DependencyInjection/MabaGentleForceExtension.php
+++ b/src/DependencyInjection/MabaGentleForceExtension.php
@@ -89,14 +89,13 @@ class MabaGentleForceExtension extends Extension
             return;
         }
 
-        $parameters = ['host' => $redisConfig['host']];
+        $parameters = [];
         $options = null;
 
-        if (isset($redisConfig['parameters'])) {
+        if (isset($redisConfig['host'])) {
+            $parameters = ['host' => $redisConfig['host']];
+        } elseif (isset($redisConfig['parameters']) && count($redisConfig['parameters']) > 0) {
             $parameters = $redisConfig['parameters'];
-        }
-
-        if (isset($redisConfig['options'])) {
             $options = $redisConfig['options'];
         }
 

--- a/tests/Functional/Fixtures/config/redis_sentinel.yml
+++ b/tests/Functional/Fixtures/config/redis_sentinel.yml
@@ -1,0 +1,15 @@
+maba_gentle_force:
+    redis:
+        parameters:
+          - 'tcp://127.0.0.1:17000'
+          - 'tcp://127.0.0.1:17001'
+          - 'tcp://127.0.0.1:17002'
+        options:
+            replication: sentinel
+            service: master
+            parameters:
+                password: pass
+    limits:
+        use_case:
+            - max_usages: 1
+              period: 1

--- a/tests/Functional/FunctionalRedisSentinelTest.php
+++ b/tests/Functional/FunctionalRedisSentinelTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Maba\Bundle\GentleForceBundle\Tests\Functional;
+
+use Predis\Configuration\OptionsInterface;
+
+class FunctionalRedisSentinelTest extends FunctionalThrottlerTestCase
+{
+    public function testConnection()
+    {
+        $container = $this->setUpContainer('redis_sentinel');
+        /** @var OptionsInterface $options */
+        $options = $container->get('maba_gentle_force.redis_client')->getOptions();
+
+        $this->assertTrue($options->defined('replication'));
+        $this->assertTrue($options->defined('service'));
+        $this->assertTrue($options->defined('parameters'));
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -56,6 +56,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         '2_in_03_no_bucketed' => [
@@ -108,6 +109,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         '10_s' => [
@@ -158,9 +160,11 @@ class ConfigurationTest extends TestCase
             [
                 [
                     'redis' => [
+                        'host' => 'localhost',
                         'service_id' => 'redis_service_id',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [],
                     'strategies' => [
@@ -179,9 +183,11 @@ class ConfigurationTest extends TestCase
             [
                 [
                     'redis' => [
+                        'host' => 'localhost',
                         'service_id' => 'redis_service_id',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'ignore',
+                        'parameters' => [],
                     ],
                     'limits' => [],
                     'strategies' => [
@@ -203,6 +209,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         'api_request' => [
@@ -250,6 +257,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         'api_request' => [
@@ -312,6 +320,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         'api_request' => [
@@ -351,6 +360,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => null,
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [],
                     'strategies' => [
@@ -391,6 +401,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         'api_request' => [
@@ -447,6 +458,7 @@ class ConfigurationTest extends TestCase
                         'host' => 'localhost',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
+                        'parameters' => [],
                     ],
                     'limits' => [
                         'api_request' => [

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -160,7 +160,6 @@ class ConfigurationTest extends TestCase
             [
                 [
                     'redis' => [
-                        'host' => 'localhost',
                         'service_id' => 'redis_service_id',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'fail',
@@ -180,10 +179,41 @@ class ConfigurationTest extends TestCase
                 ],
                 'redis_service_id.yml',
             ],
+            'Redis sentinel case' => [
+                [
+                    'redis' => [
+                        'prefix' => null,
+                        'failure_strategy' => 'fail',
+                        'parameters' => [
+                            'tcp://127.0.0.1:17000',
+                            'tcp://127.0.0.1:17001',
+                            'tcp://127.0.0.1:17002',
+                        ],
+                        'options' => [
+                            'replication' => 'sentinel',
+                            'service' => 'master',
+                            'parameters' => [
+                                'password' => 'pass'
+                            ]
+                        ]
+                    ],
+                    'limits' => [],
+                    'strategies' => [
+                        'default' => 'headers',
+                        'headers' => [
+                            'requests_available_header' => null,
+                            'wait_for_header' => null,
+                            'content' => 'Too many requests',
+                            'content_type' => 'text/plain; charset=UTF-8',
+                        ],
+                    ],
+                    'listeners' => [],
+                ],
+                'redis_sentinel.yml',
+            ],
             [
                 [
                     'redis' => [
-                        'host' => 'localhost',
                         'service_id' => 'redis_service_id',
                         'prefix' => 'my_prefix',
                         'failure_strategy' => 'ignore',

--- a/tests/Unit/DependencyInjection/Fixtures/invalid/redis.yml
+++ b/tests/Unit/DependencyInjection/Fixtures/invalid/redis.yml
@@ -3,3 +3,5 @@ maba_gentle_force:
         host: localhost
         service_id: abc
         prefix: my_prefix
+        parameters: []
+        options: []

--- a/tests/Unit/DependencyInjection/Fixtures/invalid/redis.yml
+++ b/tests/Unit/DependencyInjection/Fixtures/invalid/redis.yml
@@ -3,5 +3,3 @@ maba_gentle_force:
         host: localhost
         service_id: abc
         prefix: my_prefix
-        parameters: []
-        options: []

--- a/tests/Unit/DependencyInjection/Fixtures/redis_sentinel.yml
+++ b/tests/Unit/DependencyInjection/Fixtures/redis_sentinel.yml
@@ -1,0 +1,11 @@
+maba_gentle_force:
+    redis:
+        parameters:
+          - 'tcp://127.0.0.1:17000'
+          - 'tcp://127.0.0.1:17001'
+          - 'tcp://127.0.0.1:17002'
+        options:
+            replication: sentinel
+            service: master
+            parameters:
+                password: pass


### PR DESCRIPTION
config.yml will look like this:
```
maba_gentle_force:
    redis:
        prefix: 'gf:'
```
config_prod.yml could look like this:
```
maba_gentle_force:
    redis:
        parameters: %maba_gentle_force.redis.parameters%
        options: %maba_gentle_force.redis.options%
```
and config_dev.yml won't have any redis related config as "host" default to "localhost".