### PR TITLE
Also check for alias in the logger compiler pass

### DIFF
--- a/src/DependencyInjection/EnsureLoggerCompilerPass.php
+++ b/src/DependencyInjection/EnsureLoggerCompilerPass.php
@@ -18,7 +18,7 @@ class EnsureLoggerCompilerPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('logger')) {
+        if ($container->hasDefinition('logger') || $container->hasAlias('logger')) {
             $container->setAlias($this->loggerServiceId, 'logger');
         } else {
             $container->setDefinition($this->loggerServiceId, new Definition(NullLogger::class));


### PR DESCRIPTION
The logger compiler pass only checks the container for a service whose *id* is `'logger'`, but for version `<=3.0.0` of Monolog, `'logger'` is only an *alias* for `'monolog.logger'`, not an id (see: https://github.com/symfony/monolog-bundle/blob/804425dfceec0097bf3e5dea3a73d91e055686be/DependencyInjection/MonologExtension.php#L55). Because of this, the logger used by the Gentle Force bundle defaults to `NullLogger` and logging fails to happen.

With this change, we check both for a service whose id is `'logger'` OR for a service whose alias is `'logger'`. This makes it compatible with versions of Monolog below `3.1.x`.