### PR TITLE
Limit reset command configuration list fix

### DIFF
--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -91,10 +91,9 @@ Parameters are taken interactively.');
 
         $result = $helper->ask($input, $output, $question);
 
-        $configurationIndex = ord($result) - ord('a');
-        $configuration = $configurationList[$configurationIndex];
+        $selection = array_search($result, array_keys($options));
 
-        return $configuration;
+        return $configurationList[$selection];
     }
 
     private function describeConfiguration(ListenerConfiguration $configuration)

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -41,7 +41,7 @@ Parameters are taken interactively.');
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $configurationList = $this->configurationRegistry->getConfigurationList();
-        if (count($configurationList) === 0) {
+        if (\count($configurationList) === 0) {
             /** @var FormatterHelper $formatter */
             $formatter = $this->getHelper('formatter');
             $output->writeln($formatter->formatBlock(


### PR DESCRIPTION
Fixes a bug which appears when there are more configurations defined than there are letters in an alphabet.
Every iteration after the end of an alphabet is reached adds 1 more letter to the key of an array. After that `ord` function can't correctly resolve configuration's position.

Example:
```
php > var_dump(ord('a'));
php shell code:1:
int(97)
php > var_dump(ord('az'));
php shell code:1:
int(97)
```