### PR TITLE
Fix the following deprecation warning:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,11 @@ env:
 
 matrix:
     include:
-      - php: 5.5
-        env: COMPOSER_ARGS=""
-      - php: 5.6
-        env: COMPOSER_ARGS=""
       - php: 7.0
         env: COMPOSER_ARGS=""
       - php: 7.1
         env: COMPOSER_ARGS="" WITH_CS="true"
 
-      - php: 5.5
-        env: COMPOSER_ARGS="--prefer-lowest"
-      - php: 5.6
-        env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.0
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["symfony bundle", "rate limiter", "rate limiting", "rate limit", "brute force protection", "leaky bucket", "token bucket", "threshold", "throttle", "security", "dos protection", "brute-force", "bruteforce"],
     "type": "symfony-bundle",
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^7.0",
         "maba/gentle-force": "^0.2.1|^0.3",
         "symfony/framework-bundle": "^2.7|^3.0|^4.0",
         "maba/dependency-injection-extra": "^0.1.1|^1.0",

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -68,8 +68,6 @@ Parameters are taken interactively.');
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @param ListenerConfiguration[] $configurationList
      * @return ListenerConfiguration
      */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,8 +12,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('maba_gentle_force');
+        $treeBuilder = new TreeBuilder('maba_gentle_force');
+        // Keep compatibility with symfony/config < 4.2
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('maba_gentle_force');
 
         $children = $rootNode->children();
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('maba_gentle_force');
         // Keep compatibility with symfony/config < 4.2
-        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('maba_gentle_force');
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('maba_gentle_force');
 
         $children = $rootNode->children();
 
@@ -52,14 +52,14 @@ class Configuration implements ConfigurationInterface
         $node->validate()->ifTrue(function ($nodeConfig) {
             if (isset($nodeConfig['host'])) {
                 return isset($nodeConfig['service_id'])
-                    || (isset($nodeConfig['parameters']) && count($nodeConfig['parameters']) > 0)
+                    || (isset($nodeConfig['parameters']) && \count($nodeConfig['parameters']) > 0)
                     || isset($nodeConfig['options'])
                 ;
             }
 
             if (isset($nodeConfig['service_id'])) {
                 return isset($nodeConfig['host'])
-                    || (isset($nodeConfig['parameters']) && count($nodeConfig['parameters']) > 0)
+                    || (isset($nodeConfig['parameters']) && \count($nodeConfig['parameters']) > 0)
                     || isset($nodeConfig['options'])
                 ;
             }
@@ -161,9 +161,7 @@ class Configuration implements ConfigurationInterface
                     'max_range' => 599,
                 ]]);
                 if ($validatedStatusCode === false) {
-                    throw new InvalidConfigurationException(
-                        sprintf('Status code %s is invalid', $statusCode)
-                    );
+                    throw new InvalidConfigurationException(sprintf('Status code %s is invalid', $statusCode));
                 }
 
                 return $validatedStatusCode;
@@ -178,10 +176,10 @@ class Configuration implements ConfigurationInterface
             if (isset($configuration['success_matcher'])) {
                 $count++;
             }
-            if (count($configuration['success_statuses']) > 0) {
+            if (\count($configuration['success_statuses']) > 0) {
                 $count++;
             }
-            if (count($configuration['failure_statuses']) > 0) {
+            if (\count($configuration['failure_statuses']) > 0) {
                 $count++;
             }
 

--- a/src/DependencyInjection/MabaGentleForceExtension.php
+++ b/src/DependencyInjection/MabaGentleForceExtension.php
@@ -8,12 +8,12 @@ use Maba\GentleForce\RateLimit\UsageRateLimit;
 use Maba\GentleForce\RateLimitProvider;
 use Predis\Client;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class MabaGentleForceExtension extends Extension
@@ -96,7 +96,7 @@ class MabaGentleForceExtension extends Extension
 
         if (isset($redisConfig['host'])) {
             $parameters = ['host' => $redisConfig['host']];
-        } elseif (isset($redisConfig['parameters']) && count($redisConfig['parameters']) > 0) {
+        } elseif (isset($redisConfig['parameters']) && \count($redisConfig['parameters']) > 0) {
             $parameters = $redisConfig['parameters'];
             $options = $redisConfig['options'];
         }
@@ -114,7 +114,7 @@ class MabaGentleForceExtension extends Extension
         $strategiesConfiguration = $config['strategies'];
         $availableLimitsKeys = array_keys($config['limits']);
 
-        if (count($listenerConfigList) === 0) {
+        if (\count($listenerConfigList) === 0) {
             return;
         }
 
@@ -136,11 +136,8 @@ class MabaGentleForceExtension extends Extension
             $usedStrategies[] = $strategyId;
 
             $limitsKey = $listenerConfig['limits_key'];
-            if (!in_array($limitsKey, $availableLimitsKeys, true)) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Specified limits_key (%s) is not registered',
-                    $limitsKey
-                ));
+            if (!\in_array($limitsKey, $availableLimitsKeys, true)) {
+                throw new InvalidConfigurationException(sprintf('Specified limits_key (%s) is not registered', $limitsKey));
             }
 
             $pathPattern = '#' . str_replace('#', '\\#', $listenerConfig['path']) . '#';
@@ -170,14 +167,14 @@ class MabaGentleForceExtension extends Extension
             return new Reference($listenerConfig['success_matcher']);
         }
 
-        if (count($listenerConfig['success_statuses']) > 0) {
+        if (\count($listenerConfig['success_statuses']) > 0) {
             return new Definition(
                 ResponseCodeSuccessMatcher::class,
                 [$listenerConfig['success_statuses']]
             );
         }
 
-        if (count($listenerConfig['failure_statuses']) > 0) {
+        if (\count($listenerConfig['failure_statuses']) > 0) {
             return new Definition(
                 ResponseCodeSuccessMatcher::class,
                 [$listenerConfig['failure_statuses'], true]
@@ -205,30 +202,26 @@ class MabaGentleForceExtension extends Extension
         array $usedStrategies,
         array $config
     ) {
-        if (in_array('maba_gentle_force.strategy.log', $usedStrategies, true)) {
+        if (\in_array('maba_gentle_force.strategy.log', $usedStrategies, true)) {
             $loader->load('log_strategy.xml');
         }
 
         $recaptchaNeeded = false;
-        if (in_array('maba_gentle_force.strategy.recaptcha_headers', $usedStrategies, true)) {
+        if (\in_array('maba_gentle_force.strategy.recaptcha_headers', $usedStrategies, true)) {
             $loader->load('recaptcha/headers.xml');
             $recaptchaNeeded = true;
         }
-        if (in_array('maba_gentle_force.strategy.recaptcha_template', $usedStrategies, true)) {
+        if (\in_array('maba_gentle_force.strategy.recaptcha_template', $usedStrategies, true)) {
             $loader->load('recaptcha/template.xml');
             $recaptchaNeeded = true;
         }
         if ($recaptchaNeeded) {
             if (!isset($config['recaptcha'])) {
-                throw new InvalidConfigurationException(
-                    'You need to configure "recaptcha" node to use any of recaptcha_* strategies'
-                );
+                throw new InvalidConfigurationException('You need to configure "recaptcha" node to use any of recaptcha_* strategies');
             }
 
             if (!class_exists('ReCaptcha\ReCaptcha')) {
-                throw new InvalidConfigurationException(
-                    'You need to install "google/recaptcha" library to use any of recaptcha_* strategies'
-                );
+                throw new InvalidConfigurationException('You need to install "google/recaptcha" library to use any of recaptcha_* strategies');
             }
 
             $loader->load('recaptcha/main.xml');

--- a/src/DependencyInjection/StrategyValidationCompilerPass.php
+++ b/src/DependencyInjection/StrategyValidationCompilerPass.php
@@ -18,18 +18,12 @@ class StrategyValidationCompilerPass implements CompilerPassInterface
 
         foreach ($strategyIdList as $strategyId) {
             if (!$container->hasDefinition($strategyId)) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Gentle force strategy "%s" does not exist in service container',
-                    $strategyId
-                ));
+                throw new InvalidConfigurationException(sprintf('Gentle force strategy "%s" does not exist in service container', $strategyId));
             }
 
             $definition = $container->getDefinition($strategyId);
             if (!$definition->isPublic()) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Service "%s" must be public as this is required for gentle force strategies',
-                    $strategyId
-                ));
+                throw new InvalidConfigurationException(sprintf('Service "%s" must be public as this is required for gentle force strategies', $strategyId));
             }
         }
     }

--- a/src/Listener/CompositeIncreaseResult.php
+++ b/src/Listener/CompositeIncreaseResult.php
@@ -95,7 +95,6 @@ class CompositeIncreaseResult
     }
 
     /**
-     * @param ListenerConfiguration $configuration
      * @return IncreaseResult
      */
     public function getResultByConfiguration(ListenerConfiguration $configuration)

--- a/src/Listener/ConfigurationManager.php
+++ b/src/Listener/ConfigurationManager.php
@@ -67,7 +67,7 @@ class ConfigurationManager
     {
         $controller = $request->attributes->get('_controller');
 
-        return $controller !== null && in_array($controller, $this->whitelistedControllers, true);
+        return $controller !== null && \in_array($controller, $this->whitelistedControllers, true);
     }
 
     private function checkAndIncrease(
@@ -99,7 +99,7 @@ class ConfigurationManager
         $identifierHelper = $this->createIdentifierHelper($request);
 
         foreach ($this->configurationRegistry->getConfigurationList() as $configuration) {
-            if (in_array($configuration->getStrategyId(), $strategyList, true)) {
+            if (\in_array($configuration->getStrategyId(), $strategyList, true)) {
                 $this->reset($identifierHelper, $configuration);
             }
         }

--- a/src/Listener/IdentifierHelper.php
+++ b/src/Listener/IdentifierHelper.php
@@ -41,7 +41,7 @@ class IdentifierHelper
 
     private function getConcreteIdentifierByType($identifierType)
     {
-        if (array_key_exists($identifierType, $this->identifiers)) {
+        if (\array_key_exists($identifierType, $this->identifiers)) {
             return $this->identifiers[$identifierType];
         }
 

--- a/src/Listener/ListenerConfiguration.php
+++ b/src/Listener/ListenerConfiguration.php
@@ -69,7 +69,6 @@ class ListenerConfiguration
     }
 
     /**
-     * @param array $hosts
      * @return $this
      */
     public function setHosts(array $hosts)
@@ -88,7 +87,6 @@ class ListenerConfiguration
     }
 
     /**
-     * @param array $methods
      * @return $this
      */
     public function setMethods(array $methods)
@@ -126,7 +124,6 @@ class ListenerConfiguration
     }
 
     /**
-     * @param array $identifierTypes
      * @return $this
      */
     public function setIdentifierTypes(array $identifierTypes)
@@ -164,7 +161,6 @@ class ListenerConfiguration
     }
 
     /**
-     * @param SuccessMatcherInterface|null $successMatcher
      * @return $this
      */
     public function setSuccessMatcher(SuccessMatcherInterface $successMatcher = null)

--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -93,7 +93,6 @@ class RequestListener implements EventSubscriberInterface
     }
 
     /**
-     * @param Request $request
      * @return CompositeIncreaseResult|null
      */
     private function getAndRemoveCompositeResult(Request $request)

--- a/src/Listener/RequestMatcher.php
+++ b/src/Listener/RequestMatcher.php
@@ -12,11 +12,11 @@ class RequestMatcher
             return false;
         }
 
-        if (count($configuration->getMethods()) > 0 && !$this->methodMatches($configuration, $request)) {
+        if (\count($configuration->getMethods()) > 0 && !$this->methodMatches($configuration, $request)) {
             return false;
         }
 
-        if (count($configuration->getHosts()) > 0 && !$this->hostMatches($configuration, $request)) {
+        if (\count($configuration->getHosts()) > 0 && !$this->hostMatches($configuration, $request)) {
             return false;
         }
 
@@ -30,11 +30,11 @@ class RequestMatcher
 
     private function methodMatches(ListenerConfiguration $configuration, Request $request)
     {
-        return in_array($request->getMethod(), $configuration->getMethods(), true);
+        return \in_array($request->getMethod(), $configuration->getMethods(), true);
     }
 
     private function hostMatches(ListenerConfiguration $configuration, Request $request)
     {
-        return in_array(strtolower($request->getHost()), $configuration->getHosts(), true);
+        return \in_array(strtolower($request->getHost()), $configuration->getHosts(), true);
     }
 }

--- a/src/Service/IdentifierBuilder.php
+++ b/src/Service/IdentifierBuilder.php
@@ -5,7 +5,6 @@ namespace Maba\Bundle\GentleForceBundle\Service;
 class IdentifierBuilder
 {
     /**
-     * @param array $identifiers
      * @return string
      *
      * @api

--- a/src/Service/IdentifierProvider/IdentifierProviderInterface.php
+++ b/src/Service/IdentifierProvider/IdentifierProviderInterface.php
@@ -10,8 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 interface IdentifierProviderInterface
 {
     /**
-     * @param Request $request
-     *
      * @return string|null
      *
      * @api

--- a/src/Service/RequestIdentifierProvider.php
+++ b/src/Service/RequestIdentifierProvider.php
@@ -22,8 +22,7 @@ class RequestIdentifierProvider
 
     /**
      * @param string $identifierType
-     * @param Request $request
-     * @return null|string
+     * @return string|null
      *
      * @api
      */
@@ -46,10 +45,7 @@ class RequestIdentifierProvider
     private function getIdentifierProvider($identifierType)
     {
         if (!isset($this->identifierProviders[$identifierType])) {
-            throw new InvalidArgumentException(sprintf(
-                'Identifier provider for "%s" is not available',
-                $identifierType
-            ));
+            throw new InvalidArgumentException(sprintf('Identifier provider for "%s" is not available', $identifierType));
         }
 
         return $this->identifierProviders[$identifierType];

--- a/src/Service/ResponseModifyingStrategyInterface.php
+++ b/src/Service/ResponseModifyingStrategyInterface.php
@@ -11,9 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
 interface ResponseModifyingStrategyInterface extends StrategyInterface
 {
     /**
-     * @param IncreaseResult $increaseResult
-     * @param Response $response
-     *
      * @api
      */
     public function modifyResponse(IncreaseResult $increaseResult, Response $response);

--- a/src/Service/Strategy/LogStrategy.php
+++ b/src/Service/Strategy/LogStrategy.php
@@ -12,7 +12,6 @@ class LogStrategy implements StrategyInterface
     private $level;
 
     /**
-     * @param LoggerInterface $logger
      * @param string $level
      */
     public function __construct(LoggerInterface $logger, $level)

--- a/src/Service/Strategy/RecaptchaHeadersStrategy.php
+++ b/src/Service/Strategy/RecaptchaHeadersStrategy.php
@@ -17,10 +17,8 @@ class RecaptchaHeadersStrategy implements ResponseModifyingStrategyInterface
     private $unlockUrlHeaderName;
 
     /**
-     * @param ResponseModifyingStrategyInterface $internalStrategy
      * @param string $headerName
      * @param string $siteKey
-     * @param UrlGeneratorInterface $urlGenerator
      * @param string $unlockUrlHeaderName
      */
     public function __construct(

--- a/src/Service/Strategy/RecaptchaTemplateStrategy.php
+++ b/src/Service/Strategy/RecaptchaTemplateStrategy.php
@@ -18,9 +18,6 @@ class RecaptchaTemplateStrategy implements StrategyInterface
     private $template;
 
     /**
-     * @param EngineInterface $templating
-     * @param RequestStack $requestStack
-     * @param UrlGeneratorInterface $urlGenerator
      * @param string $googleRecaptchaSiteKey
      * @param string $template
      */

--- a/src/Service/StrategyInterface.php
+++ b/src/Service/StrategyInterface.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
 interface StrategyInterface
 {
     /**
-     * @param CompositeIncreaseResult $result
      * @return Response|null returns null if request should be proceeded
      *
      * @api

--- a/src/Service/StrategyManager.php
+++ b/src/Service/StrategyManager.php
@@ -21,7 +21,6 @@ class StrategyManager
     }
 
     /**
-     * @param CompositeIncreaseResult $result
      * @return Response|null
      */
     public function getRateLimitExceededResponse(CompositeIncreaseResult $result)
@@ -48,18 +47,14 @@ class StrategyManager
     }
 
     /**
-     * @param ListenerConfiguration $configuration
      * @return StrategyInterface
      */
     private function getStrategyForConfiguration(ListenerConfiguration $configuration)
     {
         $strategyId = $configuration->getStrategyId();
 
-        if (!in_array($strategyId, $this->strategies, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Given strategy (%s) was not registered with strategy manager',
-                $strategyId
-            ));
+        if (!\in_array($strategyId, $this->strategies, true)) {
+            throw new InvalidArgumentException(sprintf('Given strategy (%s) was not registered with strategy manager', $strategyId));
         }
 
         /** @var StrategyInterface $strategy */

--- a/src/Service/SuccessMatcher/ResponseCodeSuccessMatcher.php
+++ b/src/Service/SuccessMatcher/ResponseCodeSuccessMatcher.php
@@ -11,7 +11,6 @@ class ResponseCodeSuccessMatcher implements SuccessMatcherInterface
     private $inverse;
 
     /**
-     * @param array $statusCodes
      * @param bool $inverse
      */
     public function __construct(array $statusCodes, $inverse = false)
@@ -21,11 +20,10 @@ class ResponseCodeSuccessMatcher implements SuccessMatcherInterface
     }
 
     /**
-     * @param Response $response
      * @return bool
      */
     public function isResponseSuccessful(Response $response)
     {
-        return $this->inverse xor in_array($response->getStatusCode(), $this->statusCodes, true);
+        return $this->inverse xor \in_array($response->getStatusCode(), $this->statusCodes, true);
     }
 }

--- a/src/Service/SuccessMatcherInterface.php
+++ b/src/Service/SuccessMatcherInterface.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpFoundation\Response;
 interface SuccessMatcherInterface
 {
     /**
-     * @param Response $response
      * @return bool
      *
      * @api

--- a/tests/Functional/Fixtures/TestKernel.php
+++ b/tests/Functional/Fixtures/TestKernel.php
@@ -6,8 +6,8 @@ use Maba\Bundle\GentleForceBundle\MabaGentleForceBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class TestKernel extends Kernel
 {

--- a/tests/Unit/Listener/RequestMatcherTest.php
+++ b/tests/Unit/Listener/RequestMatcherTest.php
@@ -4,8 +4,8 @@ namespace Maba\Bundle\GentleForce\Tests\Unit\Listener;
 
 use Maba\Bundle\GentleForceBundle\Listener\ListenerConfiguration;
 use Maba\Bundle\GentleForceBundle\Listener\RequestMatcher;
-use Symfony\Component\HttpFoundation\Request;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 class RequestMatcherTest extends TestCase
 {
@@ -27,7 +27,6 @@ class RequestMatcherTest extends TestCase
 
     /**
      * @param bool $expected
-     * @param Request $request
      *
      * @dataProvider dataProviderForPathMatch
      */

--- a/tests/Unit/Service/Strategy/HeadersStrategyTest.php
+++ b/tests/Unit/Service/Strategy/HeadersStrategyTest.php
@@ -18,7 +18,7 @@ class HeadersStrategyTest extends TestCase
         $strategy = new HeadersStrategy('Retry-After');
         $response = $strategy->getRateLimitExceededResponse($this->buildResult());
         $this->assertSame(429, $response->getStatusCode());
-        $this->assertSame(15, $response->headers->get('Retry-After'));
+        $this->assertSame(15, (int) $response->headers->get('Retry-After'));
     }
 
     public function testGetRateLimitExceededResponseWithoutHeader()
@@ -38,7 +38,7 @@ class HeadersStrategyTest extends TestCase
         $response = new Response('my content', 201, ['custom-header' => 'abc']);
         $strategy->modifyResponse($this->buildIncreaseResult(), $response);
         $this->assertSame(201, $response->getStatusCode());
-        $this->assertSame(3, $response->headers->get('Requests-Available'));
+        $this->assertSame(3, (int) $response->headers->get('Requests-Available'));
     }
 
     public function testModifyResponseWithoutHeader()


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "maba_gentle_force" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.