### PR TITLE
Catch Predis\ClientException when no Sentinels are available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "6.5|^7.5|^8.5",
         "sebastian/comparator": "^2.1|^3.0.2",
         "symfony/security-bundle": "^4.3|^5.0",
         "doctrine/cache": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",
-        "phpunit/phpunit": "6.5|^7.5|^8.5",
+        "phpunit/phpunit": "^8.5",
         "sebastian/comparator": "^2.1|^3.0.2",
         "symfony/security-bundle": "^4.3|^5.0",
         "doctrine/cache": "^1.6",

--- a/tests/Functional/FunctionalRecaptchaTemplateStrategyTest.php
+++ b/tests/Functional/FunctionalRecaptchaTemplateStrategyTest.php
@@ -16,25 +16,32 @@ class FunctionalRecaptchaTemplateStrategyTest extends FunctionalRequestTestCase
         $request = $this->createRequest(self::PATH_API1, self::DEFAULT_IP);
         $request->setMethod('POST');
         $response = $this->handleRequest($request);
-        $this->assertStringContainsString(
+        $this->checkIfStringExists(
             '<html',
             $response->getContent(),
             'Expected response to contain <html> tag'
         );
-        $this->assertStringContainsString(
+        $this->checkIfStringExists(
             'my_recaptcha_site_key',
             $response->getContent(),
             'Expected response to contain recaptcha site key'
         );
-        $this->assertStringContainsString(
+        $this->checkIfStringExists(
             '/prefix/gentle-force/recaptcha/unlock',
             $response->getContent(),
             'Expected response to contain unlock URL'
         );
-        $this->assertStringContainsString(
+        $this->checkIfStringExists(
             'Custom template',
             $response->getContent(),
             'Expected response to be generated from customized template'
         );
+    }
+
+    private function checkIfStringExists(string $needle, string $haystack, string $message)
+    {
+        if (mb_strpos($haystack, $needle) === false) {
+            $this->fail($message);
+        }
     }
 }


### PR DESCRIPTION
When "No sentinel server available for autodiscovery" happens, `FailureHandlingThrottler` should catch this.